### PR TITLE
Accessibility Suggestion

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -285,7 +285,7 @@ input#nav {
     border: none;
     background: transparent;
     color: white;
-    outline: none;
+    outline-color: transparent;
 }
 svg#toggle {
     fill: white;


### PR DESCRIPTION
Small accessibility defect in CSS when using "outline: none" was fixed. Made simple changes following best practices to prevent users with higher contrasts from experiencing bugs when using the tab key to select buttons, inputs, etc. Reference: https://www.youtube.com/shorts/4B_4WLpbyp8